### PR TITLE
[#111092124] Media Projection Video Source

### DIFF
--- a/src/main/java/net/majorkernelpanic/streaming/video/source/ProjectionVideoSource.java
+++ b/src/main/java/net/majorkernelpanic/streaming/video/source/ProjectionVideoSource.java
@@ -2,13 +2,16 @@ package net.majorkernelpanic.streaming.video.source;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.hardware.display.DisplayManager;
 import android.hardware.display.VirtualDisplay;
 import android.media.projection.MediaProjection;
 import android.media.projection.MediaProjectionManager;
+import android.os.Bundle;
 import android.util.DisplayMetrics;
+import android.util.Log;
 
 public class ProjectionVideoSource extends ActivityVideoSource {
 
@@ -17,7 +20,7 @@ public class ProjectionVideoSource extends ActivityVideoSource {
     VirtualDisplay mVirtualDisplay;
     int mResultCode;
     Intent mResultData;
-    DisplayMetrics mMetrics;
+    private ActivityCallbacks mActivityCallbacks;
 
     // requires API 21
     @SuppressLint("NewApi")
@@ -29,8 +32,9 @@ public class ProjectionVideoSource extends ActivityVideoSource {
 
         mMediaProjectionManager = (MediaProjectionManager) activity.getSystemService(Context.MEDIA_PROJECTION_SERVICE);
 
-        mMetrics = new DisplayMetrics();
-        activity.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+        mActivityCallbacks = new ActivityCallbacks();
+
+        activity.getApplication().registerActivityLifecycleCallbacks(mActivityCallbacks);
     }
 
     // requires API 21
@@ -48,15 +52,6 @@ public class ProjectionVideoSource extends ActivityVideoSource {
                 null, // callback
                 null  // handler
         );
-
-        mRunnable = new Runnable() {
-            @Override
-            public void run() {
-                if (mRunnable != null) mHandler.postDelayed(this, mRefreshRate);
-            }
-        };
-
-        mHandler.postDelayed(mRunnable, mRefreshRate);
     }
 
     // requires API 21
@@ -73,6 +68,48 @@ public class ProjectionVideoSource extends ActivityVideoSource {
         if (mMediaProjection != null) {
             mMediaProjection.stop();
             mMediaProjection = null;
+        }
+
+        if (mActivityCallbacks != null) {
+            mActivity.getApplication().unregisterActivityLifecycleCallbacks(mActivityCallbacks);
+            mActivityCallbacks = null;
+        }
+    }
+
+    class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
+        @Override
+        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+
+        }
+
+        @Override
+        public void onActivityStarted(Activity activity) {
+            Log.i("SKILLZ", "Started");
+        }
+
+        @Override
+        public void onActivityResumed(Activity activity) {
+            Log.i("SKILLZ", "Resumed");
+        }
+
+        @Override
+        public void onActivityPaused(Activity activity) {
+            Log.i("SKILLZ", "Paused");
+        }
+
+        @Override
+        public void onActivityStopped(Activity activity) {
+            Log.i("SKILLZ", "Stopped");
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+
+        }
+
+        @Override
+        public void onActivityDestroyed(Activity activity) {
+
         }
     }
 }

--- a/src/main/java/net/majorkernelpanic/streaming/video/source/ProjectionVideoSource.java
+++ b/src/main/java/net/majorkernelpanic/streaming/video/source/ProjectionVideoSource.java
@@ -1,0 +1,78 @@
+package net.majorkernelpanic.streaming.video.source;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.hardware.display.DisplayManager;
+import android.hardware.display.VirtualDisplay;
+import android.media.projection.MediaProjection;
+import android.media.projection.MediaProjectionManager;
+import android.util.DisplayMetrics;
+
+public class ProjectionVideoSource extends ActivityVideoSource {
+
+    MediaProjectionManager mMediaProjectionManager;
+    MediaProjection mMediaProjection;
+    VirtualDisplay mVirtualDisplay;
+    int mResultCode;
+    Intent mResultData;
+    DisplayMetrics mMetrics;
+
+    // requires API 21
+    @SuppressLint("NewApi")
+    public ProjectionVideoSource(Activity activity, int resultCode, Intent resultData) {
+        super(activity);
+
+        mResultCode = resultCode;
+        mResultData = resultData;
+
+        mMediaProjectionManager = (MediaProjectionManager) activity.getSystemService(Context.MEDIA_PROJECTION_SERVICE);
+
+        mMetrics = new DisplayMetrics();
+        activity.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+    }
+
+    // requires API 21
+    @SuppressLint("NewApi")
+    @Override
+    public void afterStart() {
+        mMediaProjection = mMediaProjectionManager.getMediaProjection(mResultCode, mResultData);
+        mVirtualDisplay = mMediaProjection.createVirtualDisplay(
+                "skillz",
+                mStream.getVideoQuality().resX,
+                mStream.getVideoQuality().resY,
+                DisplayMetrics.DENSITY_LOW,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+                mSurface,
+                null, // callback
+                null  // handler
+        );
+
+        mRunnable = new Runnable() {
+            @Override
+            public void run() {
+                if (mRunnable != null) mHandler.postDelayed(this, mRefreshRate);
+            }
+        };
+
+        mHandler.postDelayed(mRunnable, mRefreshRate);
+    }
+
+    // requires API 21
+    @SuppressLint("NewApi")
+    @Override
+    public void afterStop() {
+        super.afterStop();
+
+        if (mVirtualDisplay != null) {
+            mVirtualDisplay.release();
+            mVirtualDisplay = null;
+        }
+
+        if (mMediaProjection != null) {
+            mMediaProjection.stop();
+            mMediaProjection = null;
+        }
+    }
+}

--- a/src/main/java/net/majorkernelpanic/streaming/video/source/ProjectionVideoSource.java
+++ b/src/main/java/net/majorkernelpanic/streaming/video/source/ProjectionVideoSource.java
@@ -13,14 +13,17 @@ import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
+import net.majorkernelpanic.streaming.Session;
+
 public class ProjectionVideoSource extends ActivityVideoSource {
 
-    MediaProjectionManager mMediaProjectionManager;
-    MediaProjection mMediaProjection;
-    VirtualDisplay mVirtualDisplay;
-    int mResultCode;
-    Intent mResultData;
+    private MediaProjectionManager mMediaProjectionManager;
+    private MediaProjection mMediaProjection;
+    private VirtualDisplay mVirtualDisplay;
+    private int mResultCode;
+    private Intent mResultData;
     private ActivityCallbacks mActivityCallbacks;
+    private Session mSession = null;
 
     // requires API 21
     @SuppressLint("NewApi")
@@ -74,6 +77,12 @@ public class ProjectionVideoSource extends ActivityVideoSource {
             mActivity.getApplication().unregisterActivityLifecycleCallbacks(mActivityCallbacks);
             mActivityCallbacks = null;
         }
+
+        mSession = null;
+    }
+
+    public void setSession(Session session) {
+        this.mSession = session;
     }
 
     class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
@@ -95,6 +104,10 @@ public class ProjectionVideoSource extends ActivityVideoSource {
         @Override
         public void onActivityPaused(Activity activity) {
             Log.i("SKILLZ", "Paused");
+
+            if (activity == mActivity && mSession != null && mSession.isStreaming()) {
+                mSession.syncStop();
+            }
         }
 
         @Override


### PR DESCRIPTION
Stream from media projection.

Requires the implementer to ask for permission. The result is then passed to the video source constructor.
